### PR TITLE
[fix]: Issue #5 - ExpressJoiSwagger._listen doesn't return node http.Server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class ExpressJoiSwagger {
   _listen(expressRouter, ...args) {
     this._buildSwaggerDefinition(expressRouter);
 
-    expressRouter.listen(...args);
+    return expressRouter.listen(...args);
   }
 
   /**


### PR DESCRIPTION
Say we implement something like this to use express-join-swagger:

```
const swagger = new ExpressJoiSwagger({
  swaggerDefinition: {
    info: {
...
```

And then:

```
  server = swagger.wrapRouter(app).listen(SERVER_PORT, () => {
```
The `server` variable here won't be a node http.Server instance, which is needed in case you're using other stuff in your app that needs it, for eg., socket.io, for which one has to do:

```
const io = require('socket.io').listen(server);
```

But this will fail since server isn't what its expected to be. One would start getting unnecessary 404s on socket.io connections from client side.